### PR TITLE
feat: support MCP tool prefixes for multi-vault use

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,8 @@ Uses the built-in `Xenova/multilingual-e5-small` model — works fully offline, 
       "command": "npx",
       "args": ["-y", "-p", "obsidian-hybrid-search@latest", "obsidian-hybrid-search-mcp"],
       "env": {
-        "OBSIDIAN_VAULT_PATH": "/path/to/your/vault"
+        "OBSIDIAN_VAULT_PATH": "/path/to/your/vault",
+        "OBSIDIAN_PREFIX": ""
       }
     }
   }
@@ -355,6 +356,7 @@ Uses the built-in `Xenova/multilingual-e5-small` model — works fully offline, 
       "args": ["-y", "-p", "obsidian-hybrid-search@latest", "obsidian-hybrid-search-mcp"],
       "env": {
         "OBSIDIAN_VAULT_PATH": "/path/to/your/vault",
+        "OBSIDIAN_PREFIX": "myvault_",
         "OBSIDIAN_IGNORE_PATTERNS": ".obsidian/**,templates/**,*.canvas",
         "OPENAI_API_KEY": "sk-or-v1-...",
         "OPENAI_BASE_URL": "https://openrouter.ai/api/v1",
@@ -376,11 +378,14 @@ The server exposes four tools:
 | `reindex` | Reindex the vault or a specific file                                                                                                                                                                                                                                                                                                                      |
 | `status`  | Show total notes, indexed count, last indexed time                                                                                                                                                                                                                                                                                                        |
 
+If `OBSIDIAN_PREFIX` is set, tool names are prefixed in the MCP list (for example `myvault_search`, `myvault_read`). By default `OBSIDIAN_PREFIX` is empty, so tool names remain `search`, `read`, `reindex`, `status`.
+
 ## Configuration
 
 | Environment variable       | Default                              | Description                                                                        |
 | -------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------- |
 | `OBSIDIAN_VAULT_PATH`      | Required for MCP; CLI auto-detects   | Absolute path to your vault                                                        |
+| `OBSIDIAN_PREFIX`          | `""`                                 | Optional MCP tool prefix, e.g. `myvault_` → `myvault_search`, `myvault_read`       |
 | `OBSIDIAN_IGNORE_PATTERNS` | `.obsidian/**,templates/**,*.canvas` | Comma-separated ignore patterns                                                    |
 | `OPENAI_API_KEY`           | —                                    | API key; omit to use local model embeddings or keyless servers (Ollama, LM Studio) |
 | `OPENAI_BASE_URL`          | `https://api.openai.com/v1`          | API base URL                                                                       |

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,9 @@
 import path from 'node:path';
 
 export const config = {
+  get obsidianPrefix(): string {
+    return process.env.OBSIDIAN_PREFIX ?? '';
+  },
   get vaultPath(): string {
     const v = process.env.OBSIDIAN_VAULT_PATH;
     if (!v) throw new Error('OBSIDIAN_VAULT_PATH environment variable is required');

--- a/src/server.ts
+++ b/src/server.ts
@@ -193,12 +193,15 @@ async function main() {
     { name: 'obsidian-hybrid-search', version },
     { capabilities: { tools: {} } },
   );
+  const toolName = (name: string): string => `${config.obsidianPrefix}${name}`;
+  const isTool = (actual: string, expected: string): boolean =>
+    actual === toolName(expected) || actual === expected;
 
   // eslint-disable-next-line @typescript-eslint/require-await
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: [
       {
-        name: 'search',
+        name: toolName('search'),
         description:
           "Search the user's personal Obsidian knowledge base — their notes, ideas, and research. " +
           'Use this tool whenever the user asks about something they may have written about, wants to find related notes, or wants to explore their knowledge graph. ' +
@@ -313,7 +316,7 @@ async function main() {
         },
       },
       {
-        name: 'reindex',
+        name: toolName('reindex'),
         description:
           'Reindex a specific file or the entire vault (incremental — only changed files)',
         inputSchema: {
@@ -331,7 +334,7 @@ async function main() {
         },
       },
       {
-        name: 'status',
+        name: toolName('status'),
         description: 'Get indexing status and configuration',
         inputSchema: {
           type: 'object',
@@ -344,7 +347,7 @@ async function main() {
         },
       },
       {
-        name: 'read',
+        name: toolName('read'),
         description:
           'Fetch one or more Obsidian notes by vault-relative path and return their full content with metadata. ' +
           'Use after search or related traversal to read the actual content of notes you found. ' +
@@ -387,7 +390,7 @@ async function main() {
     const a: Record<string, unknown> = args ?? {};
 
     try {
-      if (name === 'search') {
+      if (isTool(name, 'search')) {
         const notePath = a.path as string | undefined;
         const singleQuery = (a.query as string | undefined) ?? '';
         const extraQueriesRaw = a.queries;
@@ -418,14 +421,14 @@ async function main() {
         };
       }
 
-      if (name === 'reindex') {
+      if (isTool(name, 'reindex')) {
         const result = await handleReindex(a, contextLength, modelName, embeddingDim);
         return {
           content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
         };
       }
 
-      if (name === 'status') {
+      if (isTool(name, 'status')) {
         const stats = getStats();
         const indexingStatus = getIndexingStatus();
         const output: Record<string, unknown> = {
@@ -472,7 +475,7 @@ async function main() {
         };
       }
 
-      if (name === 'read') {
+      if (isTool(name, 'read')) {
         const rawPaths = parseArrayParam(a.paths);
         const pathsArray: string[] = Array.isArray(rawPaths)
           ? rawPaths


### PR DESCRIPTION
Add OBSIDIAN_PREFIX to namespace MCP tool names per server instance. This lets multiple vault-backed MCP servers coexist without collisions. Keep compatibility by accepting prefixed and legacy tool names.

Made-with: Cursor