### PR TITLE
fix: show SNIPPET column in default mode when results have snippets

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -313,6 +313,7 @@ function printSearchTable(
 
   if (extended && hasSnippets) heads.push('TAGS/ALIASES', 'SNIPPET');
   else if (extended) heads.push('TAGS/ALIASES');
+  else if (hasSnippets) heads.push('SNIPPET');
 
   const table = new Table({
     head: heads,
@@ -329,6 +330,8 @@ function printSearchTable(
       row.push(formatMeta(r), r.snippet ?? '');
     } else if (extended) {
       row.push(formatMeta(r));
+    } else if (hasSnippets) {
+      row.push(r.snippet ?? '');
     }
     table.push(row);
   }


### PR DESCRIPTION
## Problem

The docs show a SNIPPET column appearing by default when results have matching content:

```
┌───────┬───────────────────────────────┬────────────────────────────────────────────┐
│ SCORE │ PATH                          │ SNIPPET                                    │
├───────┼───────────────────────────────┼────────────────────────────────────────────┤
│  0.98 │ notes/pkm/zettelkasten.md     │ A note-taking method developed by Niklas   │
│       │                               │ Luhmann. Each note contains one atomic...  │
├───────┼───────────────────────────────┼────────────────────────────────────────────┤
│  0.72 │ notes/pkm/evergreen-notes.md  │ Evergreen notes are written to evolve over │
│       │                               │ time. Unlike fleeting notes, they are...   │
└───────┴───────────────────────────────┴────────────────────────────────────────────┘
```

**Actual output** for a query where snippets exist (confirmed via `--json`):

```
┌───────┬─────────────────────────────────────────────
│ SCORE │ PATH
├───────┼─────────────────────────────────────────────
│ 0.97  │ notes/metrics/enrichment/metrics-proxy.md
├───────┼─────────────────────────────────────────────
│ 0.95  │ notes/metrics/delivery-analysis/metrics-co…
└───────┴─────────────────────────────────────────────
```

No SNIPPET column. Paths also truncated more aggressively than expected.

## Root cause

In `printSearchTable`, the `hasSnippets && !extended` branch allocates two column widths (`[45, 60]`) but never pushes the SNIPPET header or row data — those are gated behind `extended && hasSnippets`:

```js
else if (hasSnippets) {
  colWidths.push(45, 60); // allocates width for SNIPPET...
}

// ...but header and row data only added when --extended is also passed:
if (extended && hasSnippets) heads.push('TAGS/ALIASES', 'SNIPPET');
// missing: else if (hasSnippets) heads.push('SNIPPET')

if (extended && hasSnippets) {
  row.push(formatMeta(r), r.snippet ?? '');
}
// missing: else if (hasSnippets) row.push(r.snippet ?? '')
```

Two consequences:

1. **SNIPPET column never renders in default mode** — `--extended` is required as a workaround, which also forces the unwanted TAGS/ALIASES column.
2. **PATH column gets width 45 instead of 60** when snippets exist — the extra `60` entry in `colWidths` is ignored by `cli-table3` since no column header was added for it, making PATH *narrower* with snippets than without.

## Fix

Add the missing `else if (hasSnippets)` branches for both the header and row rendering.

## Workaround (before this fix)

Use `--extended` to force the SNIPPET column to appear (alongside the TAGS/ALIASES column).