### PR TITLE
fix: report scan read errors and guard stale cleanup against mass deletion

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -45,6 +45,14 @@ export const config = {
     if (!v) throw new Error('OBSIDIAN_VAULT_PATH environment variable is required');
     return path.join(v, '.obsidian-hybrid-search.db');
   },
+  get cleanupMaxDeleteFraction(): number {
+    const raw = Number(process.env.OBSIDIAN_CLEANUP_MAX_DELETE_FRACTION);
+    return Number.isFinite(raw) && raw > 0 && raw <= 1 ? raw : 0.1;
+  },
+  get cleanupForce(): boolean {
+    const raw = process.env.OBSIDIAN_CLEANUP_FORCE?.trim().toLowerCase();
+    return raw === '1' || raw === 'true' || raw === 'yes';
+  },
   // internal defaults
   chunkContextFallback: 512,
   chunkOverlap: 64,

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -155,14 +155,26 @@ function resolveMarkdownReferencesForNote(
   return { links, urls: references.urls };
 }
 
-function* walkDir(dir: string, policy: IgnorePolicy): Generator<string> {
+export interface ScanResult {
+  files: string[];
+  /** Directories whose readdir failed; non-empty means the scan is PARTIAL. */
+  readErrors: string[];
+}
+
+function* walkDir(dir: string, policy: IgnorePolicy, readErrors: string[]): Generator<string> {
   let entries: { name: string; isDirectory(): boolean; isFile(): boolean }[];
   try {
     entries = readdirSync(dir, {
       withFileTypes: true,
       encoding: 'utf-8',
     });
-  } catch {
+  } catch (err) {
+    // A failed readdir (cloud FS hiccup) must NOT silently vanish a subtree:
+    // downstream stale-note cleanup would interpret it as mass deletion.
+    readErrors.push(dir);
+    console.warn(
+      `[scan] readdir failed for ${dir}: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return;
   }
   for (const entry of entries) {
@@ -170,7 +182,7 @@ function* walkDir(dir: string, policy: IgnorePolicy): Generator<string> {
     if (entry.isDirectory()) {
       const rel = toVaultRelativePath(full);
       if (!policy.isIgnored(rel + '/')) {
-        yield* walkDir(full, policy);
+        yield* walkDir(full, policy, readErrors);
       }
     } else if (entry.isFile() && entry.name.endsWith('.md')) {
       yield full;
@@ -178,16 +190,17 @@ function* walkDir(dir: string, policy: IgnorePolicy): Generator<string> {
   }
 }
 
-export function scanVault(): string[] {
+export function scanVault(): ScanResult {
   const files: string[] = [];
+  const readErrors: string[] = [];
   const policy = createIgnorePolicy();
-  for (const fullPath of walkDir(config.vaultPath, policy)) {
+  for (const fullPath of walkDir(config.vaultPath, policy, readErrors)) {
     const rel = toVaultRelativePath(fullPath);
     if (!policy.isIgnored(rel)) {
       files.push(fullPath);
     }
   }
-  return files;
+  return { files, readErrors };
 }
 
 export async function indexFile(
@@ -475,11 +488,17 @@ export async function indexVaultSync(
   header = 'Indexing vault...',
   options: { requireClean?: boolean; recoverDatabase?: () => void } = {},
 ): Promise<IndexResult> {
-  const files = scanVault();
+  const { files, readErrors } = scanVault();
+  const scanComplete = readErrors.length === 0;
   const fsPaths = new Set(files.map(toVaultRelativePath));
+  if (!scanComplete) {
+    console.warn(
+      `[scan] PARTIAL scan (${readErrors.length} unreadable dirs) - skipping stale-note cleanup`,
+    );
+  }
   await runWithDatabaseRecovery(
     'stale-note cleanup',
-    () => cleanupStaleNotes(fsPaths),
+    () => cleanupStaleNotes(scanComplete ? fsPaths : undefined),
     options.recoverDatabase,
   );
 
@@ -677,12 +696,18 @@ async function processQueue(contextLength: number): Promise<void> {
 }
 
 export async function startBackgroundIndexing(contextLength: number): Promise<void> {
-  const files = scanVault();
+  const { files, readErrors } = scanVault();
+  const scanComplete = readErrors.length === 0;
   const fsPaths = new Set(files.map(toVaultRelativePath));
+  if (!scanComplete) {
+    console.warn(
+      `[scan] PARTIAL scan (${readErrors.length} unreadable dirs) - skipping stale-note cleanup`,
+    );
+  }
   await withIndexingDbLock(() => {
     return runWithDatabaseRecovery(
       'background stale-note cleanup',
-      () => cleanupStaleNotes(fsPaths),
+      () => cleanupStaleNotes(scanComplete ? fsPaths : undefined),
       recoverDatabaseSidecarsForIndexing,
     );
   });
@@ -749,11 +774,17 @@ export function startWatcher(contextLength: number): void {
         void withIndexingDbLock(async () => {
           try {
             watcherPolicy = createIgnorePolicy();
-            const files = scanVault();
+            const { files, readErrors } = scanVault();
+            const scanComplete = readErrors.length === 0;
             const fsPaths = new Set(files.map(toVaultRelativePath));
+            if (!scanComplete) {
+              console.warn(
+                `[scan] PARTIAL scan (${readErrors.length} unreadable dirs) - skipping stale-note cleanup`,
+              );
+            }
             await runWithDatabaseRecovery(
               'watcher gitignore cleanup',
-              () => cleanupStaleNotes(fsPaths),
+              () => cleanupStaleNotes(scanComplete ? fsPaths : undefined),
               recoverDatabaseSidecarsForIndexing,
             );
             for (const file of files) {

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -452,8 +452,16 @@ export function cleanupStaleNotes(fsPaths?: Set<string>): void {
     const dbPaths = (db.prepare('SELECT path FROM notes').all() as { path: string }[]).map(
       (r) => r.path,
     );
-    for (const dbPath of dbPaths) {
-      if (!fsPaths.has(dbPath)) {
+    const stale = dbPaths.filter((p) => !fsPaths.has(p));
+    const limit = Math.max(50, Math.ceil(dbPaths.length * config.cleanupMaxDeleteFraction));
+    if (stale.length > limit && !config.cleanupForce) {
+      console.warn(
+        `[cleanup] REFUSING to delete ${stale.length}/${dbPaths.length} notes ` +
+          `(> ${config.cleanupMaxDeleteFraction * 100}% guard). ` +
+          `If this is intentional, set OBSIDIAN_CLEANUP_FORCE=1 for one run.`,
+      );
+    } else {
+      for (const dbPath of stale) {
         deleteNote(dbPath); // keepLinks=false
         deleted++;
       }

--- a/test/indexer-file.test.ts
+++ b/test/indexer-file.test.ts
@@ -187,31 +187,31 @@ describe('renderProgressLine', () => {
 
 describe('scanVault', () => {
   const scanVaultRelPaths = (): string[] =>
-    scanVault().map((file) => path.relative(vaultDir, file).split(path.sep).join('/'));
+    scanVault().files.map((file) => path.relative(vaultDir, file).split(path.sep).join('/'));
 
   it('finds markdown files in the vault', () => {
     writeFileSync(path.join(vaultDir, 'found.md'), '# Found');
-    const files = scanVault();
+    const { files } = scanVault();
     assert.ok(files.some((f) => f.endsWith('found.md')));
   });
 
   it('ignores non-markdown files', () => {
     writeFileSync(path.join(vaultDir, 'readme.txt'), 'text');
-    const files = scanVault();
+    const { files } = scanVault();
     assert.ok(!files.some((f) => f.endsWith('readme.txt')));
   });
 
   it('recurses into subdirectories', () => {
     mkdirSync(path.join(vaultDir, 'sub'), { recursive: true });
     writeFileSync(path.join(vaultDir, 'sub', 'nested.md'), '# Nested');
-    const files = scanVault();
+    const { files } = scanVault();
     assert.ok(files.some((f) => f.endsWith('nested.md')));
   });
 
   it('skips ignored directories', () => {
     mkdirSync(path.join(vaultDir, 'templates'), { recursive: true });
     writeFileSync(path.join(vaultDir, 'templates', 't.md'), '# T');
-    const files = scanVault();
+    const { files } = scanVault();
     assert.ok(!files.some((f) => f.includes('templates')));
   });
 
@@ -224,7 +224,7 @@ describe('scanVault', () => {
     writeFileSync(visiblePath, '# Visible');
 
     try {
-      const files = scanVault();
+      const { files } = scanVault();
 
       assert.ok(!files.some((f) => f.endsWith('ignored-by-git.md')));
       assert.ok(files.some((f) => f.endsWith('visible-after-gitignore.md')));

--- a/test/indexer-watcher-selection-contract.test.ts
+++ b/test/indexer-watcher-selection-contract.test.ts
@@ -66,7 +66,7 @@ beforeAll(async () => {
   const options = watchMock.mock.calls.at(-1)?.[1] as { ignored: (p: string) => boolean };
   ignored = options.ignored;
 
-  scanSet = new Set(scanVault().map(toRel));
+  scanSet = new Set(scanVault().files.map(toRel));
 });
 
 afterAll(() => {

--- a/test/scan-safety.test.ts
+++ b/test/scan-safety.test.ts
@@ -128,4 +128,47 @@ describe('cleanupStaleNotes mass-delete guard', () => {
       closeDb();
     }
   });
+
+  // The two tests above sit under the 50-note floor of
+  // Math.max(50, ceil(total * fraction)), so they only exercise the floor. With
+  // 600 notes and the default 0.1 fraction the limit is ceil(600 * 0.1) = 60,
+  // above the 50 floor, so the fraction is the binding limit. 55 stale (above
+  // the floor, below the fraction limit) must be allowed; 65 (above it) blocked.
+  it.each([
+    {
+      label: 'blocks cleanup above the fractional limit once it exceeds the floor',
+      present: 535, // 65 stale > 60 limit -> refused
+      expected: 600,
+    },
+    {
+      label: 'allows cleanup below the fractional limit even above the 50-note floor',
+      present: 545, // 55 stale: > 50 floor but <= 60 limit -> deleted
+      expected: 545,
+    },
+  ])('$label', async ({ present, expected }) => {
+    const { openDb, initVecTable, upsertNote, getDb, closeDb } = await import('../src/db.js');
+    const { cleanupStaleNotes } = await import('../src/indexer.js');
+    openDb();
+    initVecTable(4);
+    try {
+      const db = getDb();
+      for (let i = 0; i < 600; i++) {
+        upsertNote({
+          path: `note-${i}.md`,
+          title: `Note ${i}`,
+          tags: [],
+          content: `content ${i}`,
+          mtime: Date.now(),
+          hash: `hash${i}`,
+          chunks: [],
+        });
+      }
+      const fsPaths = new Set(Array.from({ length: present }, (_, i) => `note-${i}.md`));
+      cleanupStaleNotes(fsPaths);
+      const count = (db.prepare('SELECT COUNT(*) AS c FROM notes').get() as { c: number }).c;
+      expect(count).toBe(expected);
+    } finally {
+      closeDb();
+    }
+  });
 });

--- a/test/scan-safety.test.ts
+++ b/test/scan-safety.test.ts
@@ -6,9 +6,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 let vault: string;
 let originalVaultPath: string | undefined;
 let originalDbPath: string | undefined;
+let originalCleanupForce: string | undefined;
+let originalCleanupMaxDeleteFraction: string | undefined;
 beforeEach(() => {
   originalVaultPath = process.env.OBSIDIAN_VAULT_PATH;
   originalDbPath = process.env.OBSIDIAN_DB_PATH;
+  originalCleanupForce = process.env.OBSIDIAN_CLEANUP_FORCE;
+  originalCleanupMaxDeleteFraction = process.env.OBSIDIAN_CLEANUP_MAX_DELETE_FRACTION;
   vault = mkdtempSync(path.join(tmpdir(), 'ohs-scan-'));
   mkdirSync(path.join(vault, 'a'));
   writeFileSync(path.join(vault, 'a', 'one.md'), '# one');
@@ -23,6 +27,13 @@ afterEach(() => {
   else process.env.OBSIDIAN_VAULT_PATH = originalVaultPath;
   if (originalDbPath === undefined) delete process.env.OBSIDIAN_DB_PATH;
   else process.env.OBSIDIAN_DB_PATH = originalDbPath;
+  if (originalCleanupForce === undefined) delete process.env.OBSIDIAN_CLEANUP_FORCE;
+  else process.env.OBSIDIAN_CLEANUP_FORCE = originalCleanupForce;
+  if (originalCleanupMaxDeleteFraction === undefined) {
+    delete process.env.OBSIDIAN_CLEANUP_MAX_DELETE_FRACTION;
+  } else {
+    process.env.OBSIDIAN_CLEANUP_MAX_DELETE_FRACTION = originalCleanupMaxDeleteFraction;
+  }
   rmSync(vault, { recursive: true, force: true });
 });
 
@@ -57,6 +68,64 @@ describe('scanVault read-error reporting', () => {
     } finally {
       vi.doUnmock('node:fs');
       vi.resetModules();
+    }
+  });
+});
+
+describe('cleanupStaleNotes mass-delete guard', () => {
+  it('refuses to delete more than the configured fraction of the index', async () => {
+    const { openDb, initVecTable, upsertNote, getDb, closeDb } = await import('../src/db.js');
+    const { cleanupStaleNotes } = await import('../src/indexer.js');
+    openDb();
+    initVecTable(4);
+    try {
+      const db = getDb();
+      for (let i = 0; i < 100; i++) {
+        upsertNote({
+          path: `note-${i}.md`,
+          title: `Note ${i}`,
+          tags: [],
+          content: `content ${i}`,
+          mtime: Date.now(),
+          hash: `hash${i}`,
+          chunks: [],
+        });
+      }
+      // fsPaths claims 89 of 100 notes vanished
+      const fsPaths = new Set(Array.from({ length: 11 }, (_, i) => `note-${i}.md`));
+      cleanupStaleNotes(fsPaths);
+      const count = (db.prepare('SELECT COUNT(*) AS c FROM notes').get() as { c: number }).c;
+      expect(count).toBe(100); // guard tripped, nothing deleted
+    } finally {
+      closeDb();
+    }
+  });
+
+  it('allows the same cleanup when OBSIDIAN_CLEANUP_FORCE=1', async () => {
+    const { openDb, initVecTable, upsertNote, getDb, closeDb } = await import('../src/db.js');
+    const { cleanupStaleNotes } = await import('../src/indexer.js');
+    openDb();
+    initVecTable(4);
+    try {
+      const db = getDb();
+      for (let i = 0; i < 100; i++) {
+        upsertNote({
+          path: `note-${i}.md`,
+          title: `Note ${i}`,
+          tags: [],
+          content: `content ${i}`,
+          mtime: Date.now(),
+          hash: `hash${i}`,
+          chunks: [],
+        });
+      }
+      process.env.OBSIDIAN_CLEANUP_FORCE = '1';
+      const fsPaths = new Set(Array.from({ length: 11 }, (_, i) => `note-${i}.md`));
+      cleanupStaleNotes(fsPaths);
+      const count = (db.prepare('SELECT COUNT(*) AS c FROM notes').get() as { c: number }).c;
+      expect(count).toBe(11);
+    } finally {
+      closeDb();
     }
   });
 });

--- a/test/scan-safety.test.ts
+++ b/test/scan-safety.test.ts
@@ -1,0 +1,62 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let vault: string;
+let originalVaultPath: string | undefined;
+let originalDbPath: string | undefined;
+beforeEach(() => {
+  originalVaultPath = process.env.OBSIDIAN_VAULT_PATH;
+  originalDbPath = process.env.OBSIDIAN_DB_PATH;
+  vault = mkdtempSync(path.join(tmpdir(), 'ohs-scan-'));
+  mkdirSync(path.join(vault, 'a'));
+  writeFileSync(path.join(vault, 'a', 'one.md'), '# one');
+  writeFileSync(path.join(vault, 'two.md'), '# two');
+  process.env.OBSIDIAN_VAULT_PATH = vault;
+  process.env.OBSIDIAN_DB_PATH = path.join(vault, 'test.db');
+});
+afterEach(() => {
+  // isolate:false means this process is shared with every other suite in the
+  // run - a leaked env var here silently breaks unrelated test files' db opens.
+  if (originalVaultPath === undefined) delete process.env.OBSIDIAN_VAULT_PATH;
+  else process.env.OBSIDIAN_VAULT_PATH = originalVaultPath;
+  if (originalDbPath === undefined) delete process.env.OBSIDIAN_DB_PATH;
+  else process.env.OBSIDIAN_DB_PATH = originalDbPath;
+  rmSync(vault, { recursive: true, force: true });
+});
+
+describe('scanVault read-error reporting', () => {
+  it('returns files plus empty readErrors on a clean scan', async () => {
+    const { scanVault } = await import('../src/indexer.js');
+    const result = scanVault();
+    expect(result.files).toHaveLength(2);
+    expect(result.readErrors).toEqual([]);
+  });
+  it('reports readErrors instead of silently dropping a subtree', async () => {
+    // vi.spyOn on node:fs named exports fails under ESM ("Module namespace is
+    // not configurable") - fall back to vi.mock/importOriginal per the module
+    // graph, scoped to this test via resetModules + doUnmock.
+    vi.resetModules();
+    vi.doMock('node:fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:fs')>();
+      return {
+        ...actual,
+        // Simulate a Google Drive readdir failure on the 'a' subtree
+        readdirSync: ((p: unknown, o: unknown) => {
+          if (String(p).endsWith('a')) throw new Error('EIO: drive hiccup');
+          return (actual.readdirSync as (p: unknown, o: unknown) => unknown)(p, o);
+        }) as typeof actual.readdirSync,
+      };
+    });
+    try {
+      const { scanVault } = await import('../src/indexer.js');
+      const result = scanVault();
+      expect(result.readErrors).toHaveLength(1);
+      expect(result.files.map((f) => path.basename(f))).toEqual(['two.md']);
+    } finally {
+      vi.doUnmock('node:fs');
+      vi.resetModules();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

A vault scan that hit a transient `readdir` failure (network drives, cloud-synced folders) silently dropped the affected subtree and returned a short file list. The stale-note cleanup then treated every note under that subtree as deleted and removed it from the index, so one filesystem hiccup could wipe a large fraction of the database. There was also no ceiling on how much a single cleanup pass could delete.

## Fix

`scanVault` now collects read errors and returns them alongside the file list, and the indexer skips stale cleanup entirely when a scan was partial, so a failed read can no longer be mistaken for deleted notes. On top of that, `cleanupStaleNotes` gains a guard: it refuses to delete more than `Math.max(50, ceil(total * fraction))` notes in one pass (default fraction 0.1, configurable via `OBSIDIAN_CLEANUP_MAX_DELETE_FRACTION`), and logs a warning instead. A one-run `OBSIDIAN_CLEANUP_FORCE=1` escape hatch allows an intentional mass cleanup.

## Testing

Ran `npx vitest run test/scan-safety.test.ts test/indexer-file.test.ts test/indexer-watcher-selection-contract.test.ts` (3 files, 71 tests passing). `test/scan-safety.test.ts` covers the read-error reporting path, the guard tripping on a partial scan, the force override, and a new parameterized case that exercises the fractional limit above the 50-note floor (600 notes, default 0.1 fraction, limit 60: 65 stale blocked, 55 stale allowed) so both the floor and the fraction regimes are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
