### PR TITLE
fix: resolve git via PATH in eval prep script

### DIFF
--- a/eval/prepare-obsidian-help.ts
+++ b/eval/prepare-obsidian-help.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 const SOURCE_REPO = 'https://github.com/obsidianmd/obsidian-help.git';
-const GIT_EXECUTABLE = '/usr/bin/git';
+const GIT_EXECUTABLE = process.env.GIT_EXECUTABLE ?? 'git';
 
 interface PrepareObsidianHelpOptions {
   vault: string;


### PR DESCRIPTION
## Problem

`eval/prepare-obsidian-help.ts` hardcodes the git binary as `const GIT_EXECUTABLE = '/usr/bin/git';`. That path only exists on typical Linux setups. On Windows (Git for Windows) and on many macOS installs (Homebrew git under `/opt/homebrew` or `/usr/local`), git is elsewhere, so the eval prep script fails with ENOENT before it can clone the help vault.

## Fix

Resolve git through the PATH by default and allow an explicit override: `const GIT_EXECUTABLE = process.env.GIT_EXECUTABLE ?? 'git';`. `spawnSync` resolves a bare `git` against PATH on every platform, and anyone with git in a nonstandard location can still point at it via the `GIT_EXECUTABLE` environment variable. Behavior is unchanged on systems where `/usr/bin/git` was already on PATH.

## Testing

No unit test accompanies this one-line change. Verified with `npx tsc --noEmit`, which passed with no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
