### PR TITLE
fix(mcp): make HTTP transport survive daemon restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,7 +471,9 @@ obsidian-hybrid-search serve --foreground
 obsidian-hybrid-search serve --http --foreground
 ```
 
-HTTP mode uses MCP Streamable HTTP. If port 3939 is already in use, the command exits with an error instead of choosing another port automatically. Use `--port` for separate vaults.
+HTTP mode uses stateless MCP Streamable HTTP. It does not issue or validate `Mcp-Session-Id`, so an MCP client can continue making tool calls after the daemon restarts even if it still sends a stale session header. This mode is intended for the server's request/response tools and does not provide persistent SSE streams, server-initiated notifications, or SSE resume.
+
+If port 3939 is already in use, the command exits with an error instead of choosing another port automatically. Use `--port` for separate vaults.
 
 When binding beyond localhost, add the client-facing Host header with `--allowed-host <host[:port]>` or `OBSIDIAN_MCP_ALLOWED_HOSTS`; `--allow-any-host` disables Host-header protection for trusted networks.
 

--- a/src/mcp-http-server.ts
+++ b/src/mcp-http-server.ts
@@ -1,6 +1,4 @@
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
-import { randomUUID } from 'node:crypto';
 import http, {
   type IncomingMessage,
   type Server as NodeHttpServer,
@@ -27,16 +25,10 @@ export interface HttpMcpServerHandle {
   close(): Promise<void>;
 }
 
-interface McpSession {
-  transport: StreamableHTTPServerTransport;
-  server: ReturnType<typeof createMcpServer>;
-}
-
 export async function runHttpMcpServer(
   options: HttpMcpServerOptions,
 ): Promise<HttpMcpServerHandle> {
   const runtime = await createMcpRuntime();
-  const sessions = new Map<string, McpSession>();
   let actualPort = options.port;
 
   const nodeServer = http.createServer((req, res) => {
@@ -69,42 +61,22 @@ export async function runHttpMcpServer(
       return;
     }
 
-    const sessionId = req.headers['mcp-session-id'];
-    if (typeof sessionId === 'string') {
-      const session = sessions.get(sessionId);
-      if (!session) {
-        writeJson(res, 404, { error: 'unknown MCP session' });
-        return;
-      }
-      await session.transport.handleRequest(req, res);
-      return;
-    }
-
     if (req.method !== 'POST') {
-      writeJson(res, 400, { error: 'missing MCP session id' });
-      return;
-    }
-
-    const body = await readJsonBody(req);
-    if (!isInitializeRequest(body)) {
-      writeJson(res, 400, { error: 'missing MCP session id' });
+      writeJson(res, 405, { error: 'method not allowed' });
       return;
     }
 
     const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
-      onsessioninitialized: (initializedSessionId) => {
-        sessions.set(initializedSessionId, { transport, server: mcpServer });
-      },
-      onsessionclosed: (closedSessionId) => {
-        sessions.delete(closedSessionId);
-      },
+      sessionIdGenerator: undefined,
       enableDnsRebindingProtection: options.allowAnyHost !== true,
       allowedHosts: allowedHosts(options.host, actualPort, options.allowedHosts),
     });
     const mcpServer = createMcpServer(runtime);
+    res.once('close', () => {
+      void Promise.allSettled([transport.close(), mcpServer.close()]);
+    });
     await mcpServer.connect(transport);
-    await transport.handleRequest(req, res, body);
+    await transport.handleRequest(req, res);
   }
 
   await listen(nodeServer, options.host, options.port);
@@ -125,8 +97,6 @@ export async function runHttpMcpServer(
     url,
     healthUrl: `http://${options.host}:${actualPort}/health`,
     close: async () => {
-      await Promise.allSettled([...sessions.values()].map((session) => session.server.close()));
-      sessions.clear();
       await closeNodeServer(nodeServer);
       closeDb();
     },
@@ -225,12 +195,4 @@ function hasExplicitPort(host: string): boolean {
   if (host.startsWith('[')) return /\]:\d+$/.test(host);
   const colonMatches = host.match(/:/g);
   return colonMatches?.length === 1 && /:\d+$/.test(host);
-}
-
-async function readJsonBody(req: IncomingMessage): Promise<unknown> {
-  let raw = '';
-  for await (const chunk of req) {
-    raw += chunk;
-  }
-  return JSON.parse(raw) as unknown;
 }

--- a/test/mcp-http-server.test.ts
+++ b/test/mcp-http-server.test.ts
@@ -54,15 +54,15 @@ describe('runHttpMcpServer', () => {
     assert.equal(body.vaultPath, vaultDir);
   }, 30_000);
 
-  it('initializes MCP and lists tools over Streamable HTTP', async () => {
+  it('serves tools without issuing an MCP session id', async () => {
     vaultDir = createTempVault();
     server = await runHttpMcpServer({ host: '127.0.0.1', port: 0 });
 
-    const sessionId = await initializeMcpSession(server.url);
+    await initializeMcpSession(server.url);
 
     const toolsRes = await fetch(server.url, {
       method: 'POST',
-      headers: { ...mcpHeaders(), 'mcp-session-id': sessionId },
+      headers: mcpHeaders(),
       body: JSON.stringify({
         jsonrpc: '2.0',
         id: 2,
@@ -73,6 +73,7 @@ describe('runHttpMcpServer', () => {
     const toolsBody = await toolsRes.text();
 
     assert.equal(toolsRes.status, 200);
+    assert.equal(toolsRes.headers.get('mcp-session-id'), null);
     assert.match(toolsBody, /search/);
     assert.match(toolsBody, /read/);
     assert.match(toolsBody, /reindex/);
@@ -93,7 +94,7 @@ describe('runHttpMcpServer', () => {
     );
 
     assert.equal(status, 200);
-    assert.ok(sessionId);
+    assert.equal(sessionId, null);
   });
 
   it('expands host-only allowed Host entries to the bound port', async () => {
@@ -110,7 +111,7 @@ describe('runHttpMcpServer', () => {
     );
 
     assert.equal(status, 200);
-    assert.ok(sessionId);
+    assert.equal(sessionId, null);
   });
 
   it('rejects MCP initialize requests for unlisted Host headers', async () => {
@@ -141,15 +142,55 @@ describe('runHttpMcpServer', () => {
     );
 
     assert.equal(status, 200);
-    assert.ok(sessionId);
+    assert.equal(sessionId, null);
   });
+
+  it('accepts a stale session header after the HTTP server restarts', async () => {
+    vaultDir = createTempVault();
+    server = await runHttpMcpServer({ host: '127.0.0.1', port: 0 });
+    await initializeMcpSession(server.url);
+    const url = server.url;
+
+    await server.close();
+    server = await runHttpMcpServer({ host: '127.0.0.1', port: Number(new URL(url).port) });
+
+    const toolsRes = await fetch(server.url, {
+      method: 'POST',
+      headers: { ...mcpHeaders(), 'mcp-session-id': 'session-from-before-restart' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/list',
+        params: {},
+      }),
+    });
+
+    assert.equal(toolsRes.status, 200);
+    assert.equal(toolsRes.headers.get('mcp-session-id'), null);
+    assert.match(await toolsRes.text(), /search/);
+
+    const toolRes = await fetch(server.url, {
+      method: 'POST',
+      headers: { ...mcpHeaders(), 'mcp-session-id': 'session-from-before-restart' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'status', arguments: {} },
+      }),
+    });
+
+    assert.equal(toolRes.status, 200);
+    assert.equal(toolRes.headers.get('mcp-session-id'), null);
+    assert.match(await toolRes.text(), /\\"indexed\\"/);
+  }, 30_000);
 
   it('returns a readable MCP error for invalid search arguments', async () => {
     vaultDir = createTempVault();
     server = await runHttpMcpServer({ host: '127.0.0.1', port: 0 });
-    const sessionId = await initializeMcpSession(server.url);
+    await initializeMcpSession(server.url);
 
-    const body = await callTool(server.url, sessionId, 'search', { query: 'alpha', threshold: 2 });
+    const body = await callTool(server.url, 'search', { query: 'alpha', threshold: 2 });
     const result = parseToolCallResult(body);
 
     assert.equal(result.isError, true);
@@ -160,9 +201,9 @@ describe('runHttpMcpServer', () => {
   it('returns a readable MCP error for invalid read arguments', async () => {
     vaultDir = createTempVault();
     server = await runHttpMcpServer({ host: '127.0.0.1', port: 0 });
-    const sessionId = await initializeMcpSession(server.url);
+    await initializeMcpSession(server.url);
 
-    const body = await callTool(server.url, sessionId, 'read', { paths: 123 });
+    const body = await callTool(server.url, 'read', { paths: 123 });
     const result = parseToolCallResult(body);
 
     assert.equal(result.isError, true);
@@ -196,9 +237,9 @@ describe('runHttpMcpServer', () => {
     upsertMarkdownLinks('alpha.md', ['beta.md']);
     closeDb();
     server = await runHttpMcpServer({ host: '127.0.0.1', port: 0 });
-    const sessionId = await initializeMcpSession(server.url);
+    await initializeMcpSession(server.url);
 
-    const body = await callTool(server.url, sessionId, 'search', {
+    const body = await callTool(server.url, 'search', {
       path: 'alpha.md',
       related: true,
       direction: 'outgoing',
@@ -225,7 +266,7 @@ function mcpHeaders(): Record<string, string> {
 async function initializeMcpSession(
   url: string,
   extraHeaders: Record<string, string> = {},
-): Promise<string> {
+): Promise<void> {
   const initRes = await fetch(url, {
     method: 'POST',
     headers: { ...mcpHeaders(), ...extraHeaders },
@@ -240,12 +281,8 @@ async function initializeMcpSession(
       },
     }),
   });
-  const sessionId = initRes.headers.get('mcp-session-id');
-
   assert.equal(initRes.status, 200);
-  assert.ok(sessionId, 'initialize should return an MCP session id');
-
-  return sessionId;
+  assert.equal(initRes.headers.get('mcp-session-id'), null);
 }
 
 function initializeMcpSessionWithHost(
@@ -313,15 +350,10 @@ function requestHealthWithHost(url: string, hostHeader: string): Promise<number>
   });
 }
 
-async function callTool(
-  url: string,
-  sessionId: string,
-  name: string,
-  args: Record<string, unknown>,
-): Promise<string> {
+async function callTool(url: string, name: string, args: Record<string, unknown>): Promise<string> {
   const res = await fetch(url, {
     method: 'POST',
-    headers: { ...mcpHeaders(), 'mcp-session-id': sessionId },
+    headers: { ...mcpHeaders(), 'mcp-session-id': 'stale-session-header' },
     body: JSON.stringify({
       jsonrpc: '2.0',
       id: 2,


### PR DESCRIPTION
## Summary

Make the Streamable HTTP MCP server stateless so clients can continue using it after the daemon restarts.

The HTTP server no longer creates, stores, or validates `Mcp-Session-Id` values. Each `POST /mcp` request gets a short-lived `StreamableHTTPServerTransport` and MCP server instance.

This is a follow-up to #16, which introduced the shared HTTP server use case.

## Problem

The current HTTP implementation stores MCP sessions in an in-memory map:

```ts
Map<McpSessionId, McpSession>
```

After a client initializes a connection, the server returns an `Mcp-Session-Id`. The client includes this ID in later requests.

This works until the HTTP daemon restarts.

After a restart:

1. The server's in-memory session map is empty.
2. The client may still send the previous `Mcp-Session-Id`.
3. The server returns `404 unknown MCP session`.
4. Some clients do not automatically discard the stale session and initialize a new one.
5. Tool calls continue to fail until the user manually reconnects the MCP server.

I reproduced this behavior with a ChatGPT custom MCP connector through Cloudflare Access and Cloudflare Tunnel. OAuth authorization and the tunnel remained valid, but ChatGPT could no longer call the MCP tools after the local daemon restarted.

The user had to press **Reconnect** to recover.

The problem was not caused by OAuth or Cloudflare. The lost state existed only in the local process memory.

## Root cause

The HTTP transport was stateful, but its session state was process-local and temporary.

The server created a random session ID during `initialize` and stored the associated transport and MCP server in memory:

```ts
sessionIdGenerator: () => randomUUID()
```

A process restart removed this state. There was no persistent session store that could reconstruct the old MCP session.

The application also rejected a request with an unknown session header before the SDK transport could handle it:

```ts
if (!sessions.has(sessionId)) {
  return 404;
}
```

As a result, a stale session header prevented the client from recovering.

## Changes

### Stateless Streamable HTTP transport

The HTTP server now creates the transport with:

```ts
sessionIdGenerator: undefined
```

This enables the SDK's stateless Streamable HTTP mode.

The server no longer:

- generates session IDs;
- stores sessions in an in-memory map;
- rejects unknown or stale session IDs;
- requires an `initialize` request before other MCP requests.

Each `POST /mcp` request now creates:

- a new `StreamableHTTPServerTransport`;
- a new MCP server connected to the shared runtime.

The per-request transport and MCP server are closed when the HTTP response closes.

The shared search runtime, database, index, watcher, and background services remain process-level resources. They are not recreated for every request.

### HTTP method handling

`POST /mcp` remains the supported MCP request path.

Other HTTP methods on `/mcp` now return:

```text
405 Method Not Allowed
```

### Regression coverage

The HTTP MCP tests now verify that:

- initialization does not return `Mcp-Session-Id`;
- normal tool calls work without a session ID;
- allowed-host and DNS rebinding protection still work;
- a stale `Mcp-Session-Id` is accepted after the HTTP server restarts;
- both `tools/list` and a real `tools/call` succeed after the restart.

### Documentation

The README now explains that HTTP mode is stateless and documents its limitations.

## Why stateless mode fits this server

The current MCP tools are request/response operations:

- `search`
- `read`
- `status`
- `reindex`

They do not depend on a long-lived client session.

Stateless mode allows multiple MCP clients to share the same long-running search and indexing process while avoiding process-local session state that becomes invalid after a restart.

## Compatibility

This changes the HTTP transport behavior:

- the server no longer returns `Mcp-Session-Id`;
- clients do not need to store or send a session ID;
- stale session headers are ignored by the stateless SDK transport;
- persistent SSE streams are not supported;
- server-initiated notifications are not supported;
- SSE event replay and resume are not supported.

The current request/response tools do not use those stateful features.

The stdio MCP transport is unchanged.

Host-header validation and DNS rebinding protection are also unchanged.

## Validation

Automated checks completed successfully:

- focused HTTP MCP tests: 11 passed;
- full test suite: 978 passed, 2 skipped;
- TypeScript build: passed;
- formatting check: passed;
- lint: passed with existing warnings in unrelated test files;
- search quality evaluation: passed.

The restart behavior was also tested manually with the real deployment:

```text
ChatGPT
  → Cloudflare Access
  → Cloudflare Tunnel
  → local obsidian-hybrid-search daemon
```

Test sequence:

1. ChatGPT successfully called an Obsidian MCP tool.
2. The local HTTP daemon was restarted.
3. ChatGPT called the tool again using the existing connector.
4. The second call succeeded without OAuth reauthorization and without pressing Reconnect.
