### PR TITLE
fix: make registry publication propagation-safe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'v*.*.*'
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to recover (for example, v0.15.1)
+        required: true
+        type: string
 
 jobs:
   release:
@@ -16,6 +21,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Resolve release tag
+        id: release-tag
+        env:
+          DISPATCH_TAG: ${{ inputs.release_tag }}
+        run: |
+          release_tag="${DISPATCH_TAG:-$GITHUB_REF_NAME}"
+          package_version="$(node -p "require('./package.json').version")"
+          if [ "$release_tag" != "v$package_version" ]; then
+            echo "Release tag $release_tag does not match package version $package_version."
+            exit 1
+          fi
+          echo "tag=$release_tag" >> "$GITHUB_OUTPUT"
 
       - name: Wait for CI to pass for this commit
         env:
@@ -74,8 +92,8 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Publish to npm
-        run: npm publish --provenance --access public
+      - name: Publish npm package and wait for registry visibility
+        run: node scripts/publish-release-npm.mjs
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -92,3 +110,4 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
+          tag_name: ${{ steps.release-tag.outputs.tag }}

--- a/scripts/publish-release-npm.mjs
+++ b/scripts/publish-release-npm.mjs
@@ -55,8 +55,14 @@ async function exactVersionStatus(url, expectedVersion) {
 }
 
 function publishPackage() {
-  const result = spawnSync('npm', ['publish', '--provenance', '--access', 'public'], {
+  const publishArgs = ['publish', '--provenance', '--access', 'public'];
+  const npmCli = process.env.npm_execpath;
+  const command =
+    npmCli === undefined ? (process.platform === 'win32' ? 'npm.cmd' : 'npm') : process.execPath;
+  const args = npmCli === undefined ? publishArgs : [npmCli, ...publishArgs];
+  const result = spawnSync(command, args, {
     env: process.env,
+    shell: npmCli === undefined && process.platform === 'win32',
     stdio: 'inherit',
   });
   if (result.error !== undefined) throw result.error;

--- a/scripts/publish-release-npm.mjs
+++ b/scripts/publish-release-npm.mjs
@@ -1,0 +1,108 @@
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
+const DEFAULT_MAX_ATTEMPTS = 60;
+const DEFAULT_DELAY_MS = 5_000;
+
+function readIntegerSetting(name, fallback, minimum) {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < minimum) {
+    throw new Error(`${name} must be an integer greater than or equal to ${minimum}`);
+  }
+  return value;
+}
+
+function readPackageIdentity() {
+  const packagePath = path.resolve('package.json');
+  const manifest = JSON.parse(readFileSync(packagePath, 'utf-8'));
+  if (typeof manifest.name !== 'string' || manifest.name.length === 0) {
+    throw new Error(`${packagePath} must contain a non-empty package name`);
+  }
+  if (typeof manifest.version !== 'string' || manifest.version.length === 0) {
+    throw new Error(`${packagePath} must contain a non-empty package version`);
+  }
+  return { name: manifest.name, version: manifest.version };
+}
+
+function packageVersionUrl(name, version, registry) {
+  const registryBase = registry.endsWith('/') ? registry : `${registry}/`;
+  return new URL(`${encodeURIComponent(name)}/${encodeURIComponent(version)}`, registryBase);
+}
+
+async function exactVersionStatus(url, expectedVersion) {
+  const response = await fetch(url, {
+    headers: {
+      accept: 'application/json',
+      'cache-control': 'no-cache',
+    },
+  });
+  if (response.status === 404) return 'missing';
+  if (!response.ok) {
+    throw new Error(`npm registry returned status ${response.status} for ${url}`);
+  }
+
+  const manifest = await response.json();
+  if (manifest.version !== expectedVersion) {
+    throw new Error(
+      `npm registry returned unexpected version ${String(manifest.version)} for ${url}`,
+    );
+  }
+  return 'visible';
+}
+
+function publishPackage() {
+  const result = spawnSync('npm', ['publish', '--provenance', '--access', 'public'], {
+    env: process.env,
+    stdio: 'inherit',
+  });
+  if (result.error !== undefined) throw result.error;
+  return result.status ?? 1;
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function main() {
+  const { name, version } = readPackageIdentity();
+  const packageSpec = `${name}@${version}`;
+  const registry = process.env.NPM_CONFIG_REGISTRY ?? DEFAULT_REGISTRY;
+  const versionUrl = packageVersionUrl(name, version, registry);
+  const maxAttempts = readIntegerSetting('NPM_VISIBILITY_MAX_ATTEMPTS', DEFAULT_MAX_ATTEMPTS, 1);
+  const delayMs = readIntegerSetting('NPM_VISIBILITY_DELAY_MS', DEFAULT_DELAY_MS, 0);
+
+  if ((await exactVersionStatus(versionUrl, version)) === 'visible') {
+    console.log(`${packageSpec} is already published; skipping npm publish.`);
+    return 0;
+  }
+
+  console.log(`Publishing ${packageSpec} to npm...`);
+  const publishStatus = publishPackage();
+  if (publishStatus !== 0) return publishStatus;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    if ((await exactVersionStatus(versionUrl, version)) === 'visible') {
+      console.log(`${packageSpec} is visible in the npm registry.`);
+      return 0;
+    }
+    if (attempt < maxAttempts) {
+      console.log(
+        `${packageSpec} is not visible yet (attempt ${attempt}/${maxAttempts}); waiting...`,
+      );
+      await delay(delayMs);
+    }
+  }
+
+  throw new Error(`${packageSpec} is not visible after ${maxAttempts} attempts at ${registry}`);
+}
+
+try {
+  process.exitCode = await main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/test/publish-release-npm.test.ts
+++ b/test/publish-release-npm.test.ts
@@ -84,10 +84,13 @@ async function runHelper(
   npmLog: string,
   overrides: Record<string, string> = {},
 ): Promise<{ status: number | null; stderr: string; stdout: string }> {
+  const cleanEnvironment = Object.fromEntries(
+    Object.entries(process.env).filter(([name]) => name.toLowerCase() !== 'npm_execpath'),
+  );
   const child = spawn(process.execPath, [RELEASE_SCRIPT], {
     cwd: root,
     env: {
-      ...process.env,
+      ...cleanEnvironment,
       PATH: path.join(root, 'bin'),
       FAKE_NPM_LOG: npmLog,
       FAKE_NPM_EXIT_CODE: '0',

--- a/test/publish-release-npm.test.ts
+++ b/test/publish-release-npm.test.ts
@@ -1,15 +1,7 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
-import {
-  chmodSync,
-  existsSync,
-  mkdirSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -73,16 +65,14 @@ function createProject(): { npmLog: string; root: string } {
     `${JSON.stringify({ name: 'example-package', version: '1.2.3' }, null, 2)}\n`,
   );
 
-  const fakeNpm = path.join(fakeBin, 'npm');
+  const fakeNpm = path.join(root, 'fake-npm.mjs');
   writeFileSync(
     fakeNpm,
-    `#!/usr/bin/env node
-import { appendFileSync } from 'node:fs';
+    `import { appendFileSync } from 'node:fs';
 appendFileSync(process.env.FAKE_NPM_LOG, JSON.stringify(process.argv.slice(2)) + '\\n');
 process.exit(Number(process.env.FAKE_NPM_EXIT_CODE));
 `,
   );
-  chmodSync(fakeNpm, 0o755);
   cleanupTasks.push(() => rmSync(root, { force: true, recursive: true }));
 
   return { npmLog, root };
@@ -98,10 +88,11 @@ async function runHelper(
     cwd: root,
     env: {
       ...process.env,
-      PATH: `${path.join(root, 'bin')}${path.delimiter}${process.env.PATH ?? ''}`,
+      PATH: path.join(root, 'bin'),
       FAKE_NPM_LOG: npmLog,
       FAKE_NPM_EXIT_CODE: '0',
       NPM_CONFIG_REGISTRY: registry,
+      npm_execpath: path.join(root, 'fake-npm.mjs'),
       NPM_VISIBILITY_DELAY_MS: '0',
       NPM_VISIBILITY_MAX_ATTEMPTS: '3',
       ...overrides,

--- a/test/publish-release-npm.test.ts
+++ b/test/publish-release-npm.test.ts
@@ -1,0 +1,204 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, it } from 'vitest';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const RELEASE_SCRIPT = path.join(ROOT, 'scripts', 'publish-release-npm.mjs');
+const cleanupTasks: Array<() => Promise<void> | void> = [];
+
+afterEach(async () => {
+  for (const cleanup of cleanupTasks.splice(0).reverse()) {
+    await cleanup();
+  }
+});
+
+async function startRegistry(statuses: number[]): Promise<{
+  acceptHeaders: Array<string | undefined>;
+  requests: string[];
+  url: string;
+}> {
+  let requestIndex = 0;
+  const acceptHeaders: Array<string | undefined> = [];
+  const requests: string[] = [];
+  const server = createServer((req, res) => {
+    acceptHeaders.push(req.headers.accept);
+    requests.push(req.url ?? '');
+    const status = statuses[Math.min(requestIndex, statuses.length - 1)] ?? 500;
+    requestIndex += 1;
+    res.writeHead(status, { 'content-type': 'application/json' });
+    res.end(
+      JSON.stringify(
+        status === 200
+          ? { name: 'example-package', version: '1.2.3' }
+          : { error: status === 404 ? 'not found' : 'registry unavailable' },
+      ),
+    );
+  });
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  cleanupTasks.push(
+    () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  );
+
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+  return { acceptHeaders, requests, url: `http://127.0.0.1:${address.port}/` };
+}
+
+function createProject(): { npmLog: string; root: string } {
+  const root = mkdtempSync(path.join(tmpdir(), 'ohs-release-npm-'));
+  const fakeBin = path.join(root, 'bin');
+  const npmLog = path.join(root, 'npm-invocations.jsonl');
+  mkdirSync(fakeBin);
+  writeFileSync(
+    path.join(root, 'package.json'),
+    `${JSON.stringify({ name: 'example-package', version: '1.2.3' }, null, 2)}\n`,
+  );
+
+  const fakeNpm = path.join(fakeBin, 'npm');
+  writeFileSync(
+    fakeNpm,
+    `#!/usr/bin/env node
+import { appendFileSync } from 'node:fs';
+appendFileSync(process.env.FAKE_NPM_LOG, JSON.stringify(process.argv.slice(2)) + '\\n');
+process.exit(Number(process.env.FAKE_NPM_EXIT_CODE));
+`,
+  );
+  chmodSync(fakeNpm, 0o755);
+  cleanupTasks.push(() => rmSync(root, { force: true, recursive: true }));
+
+  return { npmLog, root };
+}
+
+async function runHelper(
+  root: string,
+  registry: string,
+  npmLog: string,
+  overrides: Record<string, string> = {},
+): Promise<{ status: number | null; stderr: string; stdout: string }> {
+  const child = spawn(process.execPath, [RELEASE_SCRIPT], {
+    cwd: root,
+    env: {
+      ...process.env,
+      PATH: `${path.join(root, 'bin')}${path.delimiter}${process.env.PATH ?? ''}`,
+      FAKE_NPM_LOG: npmLog,
+      FAKE_NPM_EXIT_CODE: '0',
+      NPM_CONFIG_REGISTRY: registry,
+      NPM_VISIBILITY_DELAY_MS: '0',
+      NPM_VISIBILITY_MAX_ATTEMPTS: '3',
+      ...overrides,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.setEncoding('utf-8');
+  child.stderr.setEncoding('utf-8');
+  child.stdout.on('data', (chunk: string) => (stdout += chunk));
+  child.stderr.on('data', (chunk: string) => (stderr += chunk));
+  const [status] = (await once(child, 'close')) as [number | null];
+  return { status, stderr, stdout };
+}
+
+function npmInvocations(npmLog: string): string[][] {
+  if (!existsSync(npmLog)) return [];
+  return readFileSync(npmLog, 'utf-8')
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as string[]);
+}
+
+describe('release npm publication', () => {
+  it('skips npm publish when the exact version already exists', async () => {
+    const registry = await startRegistry([200]);
+    const project = createProject();
+
+    const result = await runHelper(project.root, registry.url, project.npmLog);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(npmInvocations(project.npmLog), []);
+    assert.match(result.stdout, /example-package@1\.2\.3 is already published/);
+    assert.deepEqual(registry.requests, ['/example-package/1.2.3']);
+    assert.deepEqual(registry.acceptHeaders, ['application/json']);
+  });
+
+  it('publishes a missing version and waits until it becomes visible', async () => {
+    const registry = await startRegistry([404, 404, 200]);
+    const project = createProject();
+
+    const result = await runHelper(project.root, registry.url, project.npmLog);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(npmInvocations(project.npmLog), [
+      ['publish', '--provenance', '--access', 'public'],
+    ]);
+    assert.match(result.stdout, /is visible in the npm registry/);
+    assert.deepEqual(registry.requests, [
+      '/example-package/1.2.3',
+      '/example-package/1.2.3',
+      '/example-package/1.2.3',
+    ]);
+  });
+
+  it('fails immediately on a non-404 registry response', async () => {
+    const registry = await startRegistry([500]);
+    const project = createProject();
+
+    const result = await runHelper(project.root, registry.url, project.npmLog);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /status 500/);
+    assert.deepEqual(npmInvocations(project.npmLog), []);
+    assert.equal(registry.requests.length, 1);
+  });
+
+  it('times out after the configured visibility attempts', async () => {
+    const registry = await startRegistry([404]);
+    const project = createProject();
+
+    const result = await runHelper(project.root, registry.url, project.npmLog, {
+      NPM_VISIBILITY_MAX_ATTEMPTS: '2',
+    });
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /not visible after 2 attempts/);
+    assert.deepEqual(npmInvocations(project.npmLog), [
+      ['publish', '--provenance', '--access', 'public'],
+    ]);
+    assert.equal(registry.requests.length, 3);
+  });
+
+  it('propagates an npm publish failure without polling', async () => {
+    const registry = await startRegistry([404]);
+    const project = createProject();
+
+    const result = await runHelper(project.root, registry.url, project.npmLog, {
+      FAKE_NPM_EXIT_CODE: '23',
+    });
+
+    assert.equal(result.status, 23);
+    assert.deepEqual(npmInvocations(project.npmLog), [
+      ['publish', '--provenance', '--access', 'public'],
+    ]);
+    assert.equal(registry.requests.length, 1);
+  });
+});

--- a/test/workflows.test.ts
+++ b/test/workflows.test.ts
@@ -9,7 +9,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, '..');
 
 type WorkflowStep = {
+  env?: Record<string, unknown>;
   if?: string;
+  id?: string;
   name?: string;
   uses?: string;
   run?: string;
@@ -225,5 +227,39 @@ describe('GitHub Actions workflows', () => {
     assert.match(verifyCi.run ?? '', /status"\s*=\s*"completed"/);
     assert.match(verifyCi.run ?? '', /sleep 20/);
     assert.doesNotMatch(verifyCi.run ?? '', /Wait for CI to pass, then re-run this release/);
+  });
+
+  it('makes npm publication rerunnable and waits for exact-version visibility', () => {
+    const workflow = readWorkflow('.github/workflows/release.yml');
+    const npmRelease = stepByName(
+      workflow,
+      'release',
+      'Publish npm package and wait for registry visibility',
+    );
+
+    assert.equal(npmRelease.run, 'node scripts/publish-release-npm.mjs');
+    assert.equal(npmRelease.env?.NODE_AUTH_TOKEN, '${{ secrets.NPM_TOKEN }}');
+
+    const stepNames = workflow.jobs.release?.steps.map((step) => step.name);
+    const npmReleaseIndex = stepNames?.indexOf(npmRelease.name) ?? -1;
+    const mcpReleaseIndex = stepNames?.indexOf('Publish to MCP Registry') ?? -1;
+    assert.ok(npmReleaseIndex >= 0);
+    assert.ok(mcpReleaseIndex > npmReleaseIndex);
+  });
+
+  it('targets an explicit matching tag when a release is dispatched manually', () => {
+    const workflow = readWorkflow('.github/workflows/release.yml');
+    const workflowDispatch = workflow.on?.workflow_dispatch as
+      { inputs?: Record<string, Record<string, unknown>> } | undefined;
+    assert.equal(workflowDispatch?.inputs?.release_tag?.required, true);
+    assert.equal(workflowDispatch?.inputs?.release_tag?.type, 'string');
+
+    const resolveTag = stepByName(workflow, 'release', 'Resolve release tag');
+    assert.equal(resolveTag.id, 'release-tag');
+    assert.match(resolveTag.run ?? '', /DISPATCH_TAG:-\$GITHUB_REF_NAME/);
+    assert.match(resolveTag.run ?? '', /"v\$package_version"/);
+
+    const createRelease = stepByName(workflow, 'release', 'Create GitHub Release');
+    assert.equal(createRelease.with?.tag_name, '${{ steps.release-tag.outputs.tag }}');
   });
 });


### PR DESCRIPTION
## Summary

- make npm publishing idempotent for partial release reruns
- wait on exact npm version visibility before MCP Registry validation
- add an explicit, version-checked tag input for manual release recovery

## Root cause

The MCP Registry validated npm immediately after `npm publish` and observed a transient 404 for 0.15.1. A rerun was also unsafe because npm versions are immutable.

## Verification

- `npm run format:check`
- `npm run build`
- `npm test` (1062 passed, 2 skipped)
- `npm run lint` (0 errors)
- `npm run knip`
- pre-push ranking quality gate passed
- real npm registry check correctly skips existing 0.15.1